### PR TITLE
Fix solitaire save-state bugs and polish board UI

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -108,8 +108,7 @@ solitaire.koplugin/
 | **Hint** | Highlight a suggested move (2 seconds) |
 | **Auto** | Move all possible cards to foundations |
 | **D1/D3** | Toggle between Draw-1 and Draw-3 mode |
-| **Stats** | View game statistics |
-| **Top** | View best scores leaderboard |
+| **More** | Open statistics, leaderboard, and reset options |
 | **Close** | Save and exit the game |
 
 ### Status Bar
@@ -118,6 +117,7 @@ The status bar at the top shows:
 - **Moves** — Number of moves made
 - **Score** — Current score
 - **Time** — Elapsed game time (updates on each interaction)
+- **Mode / Stock / Waste** — Current draw mode and pile counts
 
 ---
 
@@ -326,7 +326,7 @@ self.suit_center_font = Font:getFace("cfont", math.floor(self.card_width * 0.30)
 - **Game Timer**: Tracks elapsed time per game, shown in status bar
 - **Statistics**: Full game stats tracking (wins, losses, streaks, averages, per-mode breakdown)
 - **Leaderboard**: Top 10 best scores with score, moves, time, mode, and date
-- **Stats & Top buttons**: Direct access to statistics and leaderboard from button bar
+- **More menu**: Direct access to statistics, leaderboard, and reset options
 - **Enhanced win message**: Shows time, draw mode, new-best indicators, and win streak
 
 ### v1.0

--- a/game.lua
+++ b/game.lua
@@ -55,6 +55,37 @@ function Game:copyPile(pile)
     return copy
 end
 
+function Game:isValidCard(card)
+    return type(card) == "table" and
+        type(card.suit) == "number" and card.suit >= 1 and card.suit <= 4 and
+        type(card.rank) == "number" and card.rank >= 1 and card.rank <= 13 and
+        type(card.face_up) == "boolean"
+end
+
+function Game:isValidPile(pile)
+    if type(pile) ~= "table" then
+        return false
+    end
+    for _, card in ipairs(pile) do
+        if not self:isValidCard(card) then
+            return false
+        end
+    end
+    return true
+end
+
+function Game:isValidPileGroup(piles, expected_count)
+    if type(piles) ~= "table" then
+        return false
+    end
+    for i = 1, expected_count do
+        if not self:isValidPile(piles[i]) then
+            return false
+        end
+    end
+    return true
+end
+
 -- Save current state to history (call before making a move)
 function Game:saveState()
     local state = {
@@ -540,12 +571,24 @@ end
 
 -- Load game state from saved data
 function Game:fromSaveData(data)
-    if not data then return false end
-    
-    self.stock = data.stock or {}
-    self.waste = data.waste or {}
-    self.foundations = data.foundations or {{}, {}, {}, {}}
-    self.tableau = data.tableau or {{}, {}, {}, {}, {}, {}, {}}
+    if type(data) ~= "table" then return false end
+
+    local stock = data.stock or {}
+    local waste = data.waste or {}
+    local foundations = data.foundations or {{}, {}, {}, {}}
+    local tableau = data.tableau or {{}, {}, {}, {}, {}, {}, {}}
+
+    if not self:isValidPile(stock) or
+        not self:isValidPile(waste) or
+        not self:isValidPileGroup(foundations, 4) or
+        not self:isValidPileGroup(tableau, 7) then
+        return false
+    end
+
+    self.stock = stock
+    self.waste = waste
+    self.foundations = foundations
+    self.tableau = tableau
     self.moves = data.moves or 0
     self.score = data.score or 0
     self.draw_mode = data.draw_mode or 1

--- a/solitaireui.lua
+++ b/solitaireui.lua
@@ -42,7 +42,7 @@ function SolitaireUI:init()
     end
 
     -- UI element heights
-    self.status_bar_height = self.screen_height * 0.03
+    self.status_bar_height = math.max(30, math.floor(self.screen_height * 0.035))
     self.button_bar_height = 50
 
     -- Card dimensions
@@ -127,6 +127,27 @@ function SolitaireUI:init()
     self:buildUI()
 end
 
+function SolitaireUI:updateLayoutMetrics(game_area_height)
+    local max_cards = 1
+    if self.game then
+        for _, column in ipairs(self.game.tableau) do
+            max_cards = math.max(max_cards, #column)
+        end
+    end
+
+    local top_row_height = 10 + self.card_height + self.margin
+    local available_tableau_height = game_area_height - top_row_height - self.margin
+    local comfortable_offset = math.floor(self.card_height * 0.34)
+    local minimum_offset = math.max(10, math.floor(self.card_height * 0.16))
+
+    if max_cards > 1 then
+        local fitting_offset = math.floor((available_tableau_height - self.card_height) / (max_cards - 1))
+        self.stack_offset = math.max(minimum_offset, math.min(comfortable_offset, fitting_offset))
+    else
+        self.stack_offset = comfortable_offset
+    end
+end
+
 function SolitaireUI:loadSettings()
     local ok, settings = pcall(LuaSettings.open, LuaSettings, self.settings_path)
     if ok and settings then
@@ -171,6 +192,7 @@ function SolitaireUI:buildUI()
     self.touch_zones = {}
 
     local game_area_height = self.screen_height - self.status_bar_height - self.button_bar_height
+    self:updateLayoutMetrics(game_area_height)
 
     -- Draw mode label
     local draw_mode_label = self.game.draw_mode == 3 and "D3" or "D1"
@@ -201,12 +223,8 @@ function SolitaireUI:buildUI()
                     callback = function() self:toggleDrawMode() end,
                 },
                 {
-                    text = _("Stats"),
-                    callback = function() self:showStats() end,
-                },
-                {
-                    text = _("Top"),
-                    callback = function() self:showLeaderboard() end,
+                    text = _("More"),
+                    callback = function() self:showMoreMenu() end,
                 },
                 {
                     text = _("Close"),
@@ -219,10 +237,12 @@ function SolitaireUI:buildUI()
 
     self.button_bar_height = button_bar:getSize().h
     game_area_height = self.screen_height - self.status_bar_height - self.button_bar_height
+    self:updateLayoutMetrics(game_area_height)
 
     local time_str = self.game:formatTime()
-    local status_text = string.format("Moves: %d  |  Score: %d  |  Time: %s",
-        self.game.moves, self.game.score, time_str)
+    local status_text = string.format("M:%d  S:%d  %s  %s  Stock:%d  Waste:%d",
+        self.game.moves, self.game.score, time_str, draw_mode_label,
+        #self.game.stock, #self.game.waste)
 
     local status_bar = FrameContainer:new{
         width = self.screen_width,
@@ -278,6 +298,9 @@ function SolitaireUI:drawGame(bb, offset_x, offset_y)
     end
 
     local tableau_y = y_offset + self.card_height + self.margin
+    bb:paintRect(self.margin, tableau_y - math.floor(self.margin / 2),
+        self.screen_width - 2 * self.margin, 1, Blitbuffer.COLOR_LIGHT_GRAY)
+
     local total_tableau_width = 7 * self.card_width + 6 * self.card_spacing
     local tableau_start_x = (self.screen_width - total_tableau_width) / 2
 
@@ -291,8 +314,12 @@ function SolitaireUI:drawCard(bb, x, y, card, highlighted, is_top_card, is_stock
     local is_stock = is_stock or false
     local border_width = highlighted and 3 or 1
 
+    if highlighted then
+        bb:paintRect(x - 2, y - 2, self.card_width + 4, self.card_height + 4, Blitbuffer.COLOR_GRAY)
+    end
     bb:paintRect(x, y, self.card_width, self.card_height, Blitbuffer.COLOR_WHITE)
     bb:paintBorder(x, y, self.card_width, self.card_height, border_width, Blitbuffer.COLOR_BLACK)
+    bb:paintBorder(x + 2, y + 2, self.card_width - 4, self.card_height - 4, 1, Blitbuffer.COLOR_LIGHT_GRAY)
 
     if card and card.face_up then
         local rank = self.game.RANKS[card.rank]
@@ -312,6 +339,9 @@ function SolitaireUI:drawCard(bb, x, y, card, highlighted, is_top_card, is_stock
             fgcolor = text_color,
         }
         rank_widget:paintTo(bb, x + padding, y)
+        local rw = rank_widget:getSize().w
+        local rh = rank_widget:getSize().h
+        rank_widget:paintTo(bb, x + self.card_width - rw - padding, y + self.card_height - rh - padding)
         rank_widget:free()
 
         if is_top_card then -- Draw Centered suit symbol on top card of each pile
@@ -327,6 +357,16 @@ function SolitaireUI:drawCard(bb, x, y, card, highlighted, is_top_card, is_stock
             local center_y = y + math.floor((self.card_height - sh) / 2)
             suit_center_widget:paintTo(bb, center_x, center_y)
             suit_center_widget:free()
+            local suit_br_widget = TextWidget:new{
+                text = suit,
+                face = self.suit_font,
+                fgcolor = text_color,
+            }
+            local sbw = suit_br_widget:getSize().w
+            local sbh = suit_br_widget:getSize().h
+            suit_br_widget:paintTo(bb, x + padding, y + self.card_height - sbh - padding)
+            suit_br_widget:paintTo(bb, x + self.card_width - sbw - padding, y)
+            suit_br_widget:free()
         else -- Draw smaller suit symbol in corner for non-top cards to help identify them
             local suit_tr_widget = TextWidget:new{
                 text = suit,
@@ -350,20 +390,24 @@ end
 
 function SolitaireUI:drawCardBackPattern(bb, x, y)
     local pattern_color = Blitbuffer.COLOR_DARK_GRAY
-    local density = 16
-    local spacing = math.floor(self.card_width / density)
+    local density = 12
+    local spacing = math.max(4, math.floor(self.card_width / density))
     local dot_size = math.max(1, math.floor(self.card_width * 0.03))
 
+    bb:paintBorder(x + 4, y + 4, self.card_width - 8, self.card_height - 8, 1, Blitbuffer.COLOR_GRAY)
     for i = spacing, self.card_width - spacing + dot_size, spacing do
         for j = spacing, self.card_height - spacing + dot_size/2, spacing do
-            bb:paintRect(x + i - dot_size/2, y + j - dot_size/2, dot_size, dot_size, pattern_color)
+            if ((i + j) / spacing) % 2 == 0 then
+                bb:paintRect(x + i - dot_size/2, y + j - dot_size/2, dot_size, dot_size, pattern_color)
+            end
         end
     end
 end
 
 function SolitaireUI:drawEmptySlot(bb, x, y, label)
-    bb:paintRect(x, y, self.card_width, self.card_height, Blitbuffer.COLOR_LIGHT_GRAY)
+    bb:paintRect(x, y, self.card_width, self.card_height, Blitbuffer.COLOR_WHITE)
     bb:paintBorder(x, y, self.card_width, self.card_height, 1, Blitbuffer.COLOR_GRAY)
+    bb:paintBorder(x + 4, y + 4, self.card_width - 8, self.card_height - 8, 1, Blitbuffer.COLOR_LIGHT_GRAY)
 
     if label then
         local text_widget = TextWidget:new{

--- a/solitaireui.lua
+++ b/solitaireui.lua
@@ -455,12 +455,15 @@ function SolitaireUI:drawFoundation(bb, x, y, foundation_idx)
     })
 
     local foundation = self.game.foundations[foundation_idx]
+    local is_selected = self.selected_source and
+        self.selected_source.type == "foundation" and
+        self.selected_source.index == foundation_idx
     local is_hint = self.hint_highlight and
         self.hint_highlight.foundation == foundation_idx
 
     if #foundation > 0 then
         local card = foundation[#foundation]
-        self:drawCard(bb, x, y, card, is_hint, true)
+        self:drawCard(bb, x, y, card, is_selected or is_hint, true)
     else
         local suit_symbol = Game.SUITS[foundation_idx].symbol
         self:drawEmptySlot(bb, x, y, suit_symbol)
@@ -577,6 +580,8 @@ function SolitaireUI:onTap(arg, ges)
                     self:showWinMessage()
                 end
             end
+        elseif #self.game.foundations[zone.index] > 0 then
+            self.selected_source = {type = "foundation", index = zone.index}
         end
         self:refreshUI()
         return true

--- a/solitaireui.lua
+++ b/solitaireui.lua
@@ -911,9 +911,12 @@ function SolitaireUI:showWinMessage()
 end
 
 function SolitaireUI:onClose()
-    self:saveGame()
-    -- Stop the timer refresh
     self.game:stopTimer()
+    if self.game:checkWin() then
+        self:deleteSave()
+    else
+        self:saveGame()
+    end
     UIManager:close(self)
     return true
 end

--- a/spec/game_spec.lua
+++ b/spec/game_spec.lua
@@ -1,0 +1,27 @@
+package.path = "./?.lua;" .. package.path
+
+local Game = require("game")
+
+local function assert_equal(actual, expected, message)
+    if actual ~= expected then
+        error(string.format("%s: expected %s, got %s", message, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local game = Game:new()
+local ok = game:fromSaveData({
+    stock = {},
+    waste = {},
+    foundations = {},
+    tableau = {},
+})
+
+assert_equal(ok, false, "malformed save data is rejected")
+
+local check_ok = pcall(function()
+    game:checkWin()
+end)
+
+assert_equal(check_ok, true, "rejected save data leaves game state usable")
+
+print("game_spec: ok")

--- a/spec/solitaireui_spec.lua
+++ b/spec/solitaireui_spec.lua
@@ -1,0 +1,153 @@
+package.path = "./?.lua;" .. package.path
+
+local function class()
+    local cls = {}
+    cls.__index = cls
+
+    function cls:extend(defaults)
+        defaults = defaults or {}
+        setmetatable(defaults, self)
+        defaults.__index = defaults
+        defaults.extend = self.extend
+        defaults.new = self.new
+        return defaults
+    end
+
+    function cls:new(o)
+        o = o or {}
+        setmetatable(o, self)
+        if o.init then
+            o:init()
+        end
+        return o
+    end
+
+    return cls
+end
+
+local function widget(name)
+    local cls = class()
+    cls.name = name
+    return cls
+end
+
+package.preload["ffi/blitbuffer"] = function()
+    return {
+        COLOR_BLACK = 0,
+        COLOR_DARK_GRAY = 1,
+        COLOR_GRAY = 2,
+        COLOR_LIGHT_GRAY = 3,
+        COLOR_WHITE = 4,
+    }
+end
+
+package.preload["ui/widget/buttontable"] = function()
+    local ButtonTable = widget("ButtonTable")
+    function ButtonTable:getSize()
+        return { h = 40 }
+    end
+    return ButtonTable
+end
+
+package.preload["ui/widget/container/centercontainer"] = function() return widget("CenterContainer") end
+package.preload["ui/widget/container/framecontainer"] = function() return widget("FrameContainer") end
+package.preload["ui/widget/container/inputcontainer"] = function() return widget("InputContainer") end
+package.preload["ui/widget/container/widgetcontainer"] = function() return widget("WidgetContainer") end
+package.preload["ui/widget/verticalgroup"] = function() return widget("VerticalGroup") end
+
+package.preload["device"] = function()
+    return {
+        screen = {
+            getSize = function() return { w = 600, h = 800 } end,
+            getDPI = function() return 167 end,
+        },
+        isTouchDevice = function() return true end,
+        hasKeys = function() return false end,
+    }
+end
+
+package.preload["ui/font"] = function()
+    return { getFace = function() return {} end }
+end
+
+package.preload["ui/geometry"] = function()
+    return { new = function(_, o) return o end }
+end
+
+package.preload["ui/gesturerange"] = function()
+    local GestureRange = widget("GestureRange")
+    return GestureRange
+end
+
+package.preload["ui/widget/infomessage"] = function() return widget("InfoMessage") end
+package.preload["ui/size"] = function() return {} end
+
+package.preload["ui/widget/textwidget"] = function()
+    local TextWidget = widget("TextWidget")
+    function TextWidget:getSize()
+        return { w = 10, h = 10 }
+    end
+    function TextWidget:paintTo() end
+    function TextWidget:free() end
+    return TextWidget
+end
+
+package.preload["ui/uimanager"] = function()
+    return {
+        close = function() end,
+        scheduleIn = function() end,
+        setDirty = function() end,
+        show = function() end,
+    }
+end
+
+package.preload["datastorage"] = function()
+    return { getSettingsDir = function() return "/tmp" end }
+end
+
+package.preload["luasettings"] = function()
+    return {
+        open = function()
+            return {
+                flush = function() end,
+                readSetting = function() return nil end,
+                saveSetting = function() end,
+            }
+        end,
+    }
+end
+
+package.preload["gettext"] = function()
+    return function(text) return text end
+end
+
+local SolitaireUI = require("solitaireui")
+local Game = require("game")
+
+local function assert_equal(actual, expected, message)
+    if actual ~= expected then
+        error(string.format("%s: expected %s, got %s", message, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local ui = setmetatable({
+    game = Game:new(),
+    game_started = false,
+    hint_highlight = nil,
+    selected_source = nil,
+}, { __index = SolitaireUI })
+
+ui.game.foundations[1] = {
+    { suit = 1, rank = 1, face_up = true },
+}
+ui.findTouchZone = function()
+    return { type = "foundation", index = 1 }
+end
+ui.refreshUI = function() end
+
+ui:onTap(nil, { pos = { x = 1, y = 1 } })
+
+assert_equal(ui.selected_source and ui.selected_source.type, "foundation", "foundation tap selects source type")
+assert_equal(ui.selected_source and ui.selected_source.index, 1, "foundation tap selects source index")
+
+print("solitaireui_spec: ok")

--- a/spec/solitaireui_spec.lua
+++ b/spec/solitaireui_spec.lua
@@ -150,4 +150,32 @@ ui:onTap(nil, { pos = { x = 1, y = 1 } })
 assert_equal(ui.selected_source and ui.selected_source.type, "foundation", "foundation tap selects source type")
 assert_equal(ui.selected_source and ui.selected_source.index, 1, "foundation tap selects source index")
 
+local won_game = Game:new()
+for foundation_idx = 1, 4 do
+    for rank = 1, 13 do
+        table.insert(won_game.foundations[foundation_idx], {
+            suit = foundation_idx,
+            rank = rank,
+            face_up = true,
+        })
+    end
+end
+
+local saved_won_game = false
+local deleted_won_game_save = false
+local closing_ui = setmetatable({
+    game = won_game,
+    saveGame = function()
+        saved_won_game = true
+    end,
+    deleteSave = function()
+        deleted_won_game_save = true
+    end,
+}, { __index = SolitaireUI })
+
+closing_ui:onClose()
+
+assert_equal(saved_won_game, false, "closing a won game does not save completed state")
+assert_equal(deleted_won_game_save, true, "closing a won game clears saved state")
+
 print("solitaireui_spec: ok")


### PR DESCRIPTION
1. Fix foundation card selection so foundation cards can move back to tableau as documented
2. Prevent completed games from being saved again on close
3. Reject malformed saved-game data before it can corrupt runtime state
4. Polish the board UI with clearer status text, adaptive tableau spacing, improved card rendering, cleaner empty slots, and a less crowded action bar

Tested locally with Lua specs and LuaJIT bytecode checks. Not tested on a physical KOReader device or emulator.